### PR TITLE
Upgrade regenerator dependency to v0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/TooTallNate/gnode/issues"
   },
   "dependencies": {
-    "regenerator": "~0.2.5"
+    "regenerator": "~0.3.2"
   },
   "devDependencies": {
     "co": "~2.1.0",


### PR DESCRIPTION
Among other improvements, this version of regenerator now supports `let`/`const` declarations.
