### PR TITLE
Never compile code that is already valid

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ if (!hasNativeGenerators() && !isPatchedByGnode()) {
 
   var fs = require('fs');
   var regenerator = require('regenerator');
+  var genFunExp = /\bfunction\s*\*/;
 
   /**
    * First include the regenerator runtime. It gets installed gloablly as
@@ -50,12 +51,23 @@ function gnodeJsExtensionCompiler (module, filename) {
   // strip away the shebang if present
   content = stripShebang(content);
 
-  // compile JS via facebook/regenerator
-  content = regenerator(content, {
-    includeRuntime: 'function' != typeof wrapGenerator
-  });
+  if (genFunExp.test(content) && !isValid(content)) {
+    // compile JS via facebook/regenerator
+    content = regenerator(content, {
+      includeRuntime: 'function' != typeof wrapGenerator
+    });
+  }
 
   module._compile(content, filename);
+}
+
+function isValid(content) {
+  try {
+    Function('', content);
+    return true;
+  } catch (ex) {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
This created an enormous speed improvement in startup time for my application.  The idea is that in addition to checking for the existence of `function *` you also check that the file doesn't already compile.  This lets you skip compilation of files that just mention `function *` in a comment (turns out to be surprisingly common).
