### PR TITLE
Upgrade Regenerator to v0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/TooTallNate/gnode/issues"
   },
   "dependencies": {
-    "regenerator": "~0.3.4"
+    "regenerator": "~0.4.1"
   },
   "devDependencies": {
     "co": "~2.1.0",


### PR DESCRIPTION
I revamped the way exceptions bubble up through `finally` blocks to follow the ES6 spec more closely, in particular by adopting the implementation strategy of associating a [completion record](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-completion-record-specification-type) with every `try` statement.
