### PR TITLE
Fix repl erroring on valid code.

### DIFF
--- a/fallback.js
+++ b/fallback.js
@@ -74,7 +74,13 @@ function gnodeEval (code, context, file, fn) {
     code = regenerator(code, {
       includeRuntime: 'function' != typeof wrapGenerator
     });
-
+  } catch (e) {
+    // Treat regenerator errors as syntax errors in repl.
+    // A hack to have repl interpret certain js structures correctly.
+    e.name = 'SyntaxError'
+    err = e;
+  }
+  try {
     if (this.useGlobal) {
       result = vm.runInThisContext(code, file);
     } else {


### PR DESCRIPTION
gnode repl does not handle certain valid JS:

``` js
> function *test () {};
Error: Line 1: Unexpected token ;
```

node repl wraps the input code in parens first, sees if there was a 'SyntaxError', if so, it will try again without parens.

This patch 'translates' all regenerator errors into SyntaxErrors.

No easy way to test this, passing input over stdin does not exhibit the problem.
