### PR TITLE
Update to Regenerator v0.6.3.

### DIFF
--- a/bin/gnode
+++ b/bin/gnode
@@ -31,9 +31,9 @@ hasGenerators(function (err, has) {
         // handle gnode -e|-p "console.log('script')"
         var code = process.argv[i + 1]
         if (!has) {
-          code = regenerator(code, {
+          code = regenerator.compile(code, {
             includeRuntime: true
-          });
+          }).code;
         }
         argv.push(code)
         // skip arg, we just processed it

--- a/fallback.js
+++ b/fallback.js
@@ -71,9 +71,9 @@ function gnodeEval (code, context, file, fn) {
   var err, result;
   try {
     // compile JS via facebook/regenerator
-    code = regenerator(code, {
-      includeRuntime: 'function' != typeof wrapGenerator
-    });
+    code = regenerator.compile(code, {
+      includeRuntime: 'object' !== typeof regeneratorRuntime
+    }).code;
   } catch (e) {
     // Treat regenerator errors as syntax errors in repl.
     // A hack to have repl interpret certain js structures correctly.
@@ -105,9 +105,9 @@ function evalScript (name) {
   var script = process._eval;
 
   // compile JS via facebook/regenerator
-  script = regenerator(script, {
-    includeRuntime: 'function' != typeof wrapGenerator
-  });
+  script = regenerator.compile(script, {
+    includeRuntime: 'object' !== typeof regeneratorRuntime
+  }).code;
 
   if (!Module._contextLoad) {
     var body = script;

--- a/index.js
+++ b/index.js
@@ -18,11 +18,11 @@ if (!hasNativeGenerators() && !isPatchedByGnode()) {
 
   /**
    * First include the regenerator runtime. It gets installed gloablly as
-   * `wrapGenerator`, so we just need to make sure that global function is
-   * available.
+   * `regeneratorRuntime`, so we just need to make sure that global
+   * function is available.
    */
 
-  require('vm').runInThisContext(regenerator('', { includeRuntime: true }));
+  regenerator.runtime();
 
   /**
    * Entry point for node versions that don't have Generator support.
@@ -53,9 +53,9 @@ function gnodeJsExtensionCompiler (module, filename) {
 
   if (genFunExp.test(content) && !isValid(content)) {
     // compile JS via facebook/regenerator
-    content = regenerator(content, {
-      includeRuntime: 'function' != typeof wrapGenerator
-    });
+    content = regenerator.compile(content, {
+      includeRuntime: 'object' !== typeof regeneratorRuntime
+    }).code;
   }
 
   module._compile(content, filename);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/TooTallNate/gnode/issues"
   },
   "dependencies": {
-    "regenerator": "0"
+    "regenerator": "~0.6.3"
   },
   "devDependencies": {
     "co": "~2.1.0",


### PR DESCRIPTION
The public API of the Regenerator package has changed slightly, necessitating changes to `gnode`.
