### PR TITLE
Upgrade regenerator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.9"
   - "0.10"
   - "0.11"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/TooTallNate/gnode/issues"
   },
   "dependencies": {
-    "regenerator": "~0.6.3"
+    "regenerator": "~0.8.0"
   },
   "devDependencies": {
     "co": "~2.1.0",


### PR DESCRIPTION
`regenerator<=v0.5.0` and `defs<=1.0.1` require `git://github.com/ariya/esprima.git#harmony`, that's very slow.

