### PR TITLE
Fix `npm test` failing to run

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -8,8 +8,7 @@ var spawn = require('child_process').spawn;
 
 // node executable
 var node = process.execPath || process.argv[0];
-var gnode = path.resolve(__dirname, '..', 'bin', 'gnode');
-var mocha = path.resolve(__dirname, '..', 'node_modules', '.bin', 'mocha');
+var mocha = path.resolve(__dirname, '..', 'node_modules', 'mocha', 'bin', 'mocha');
 var mochaOpts = [ '--reporter', 'spec' ];
 
 run([


### PR DESCRIPTION
Trying to run `npm test` fails because the mocha path was set to the mocha shell script instead of the mocha init script (it tried to spawn node with a shell script).
This commit fixes the issue and the tests run as expected.